### PR TITLE
[Feat] Support dynamic loading LLM providers in core module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ tests/
 *.test.*
 .eslintrc
 tsconfig.json 
+*.meta.json

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -18,10 +18,10 @@ export const createBaseConfig = (options = {}) => {
     minify: !isStart,
     sourcemap: isStart,
     metafile: true,
-    target: ['chrome58', 'firefox57', 'safari11'],
+    target: ['esnext'],
     format: 'esm',
-    platform: 'browser',
-    mainFields: ['module', 'main'], // Prioritize ESM modules
+    platform: 'neutral',
+    mainFields: ['module', 'import', 'main'], // Prioritize ESM modules
     conditions: ['import', 'module'], // Ensure ESM resolution
     define: {
       'process.env.NODE_ENV': isStart ? '"development"' : '"production"',
@@ -70,6 +70,7 @@ export const buildFormat = async (config, format, outfile) => {
   const result = await esbuild.build({
     ...config,
     format,
+    ...(format === 'cjs' ? { platform: 'node', target: ['es2017'] } : {}),
     define: {
       ...config.define,
       // Ensure consistent module loading behavior

--- a/examples/message_persistent/src/app.tsx
+++ b/examples/message_persistent/src/app.tsx
@@ -30,8 +30,7 @@ export function App() {
   const functions = {
     weather: tool({
       description: 'Get the weather in a city from a weather station',
-      parameters: z
-        .object({ cityName: z.string(), reason: z.string() }),
+      parameters: z.object({ cityName: z.string(), reason: z.string() }),
       execute: async ({ cityName, reason }, options) => {
         const getStation = options.context?.getStation;
         const station = getStation ? await getStation(cityName) : null;
@@ -40,7 +39,10 @@ export function App() {
           ? await getTemperature(cityName)
           : null;
         return {
-          llmResult: `The temperature in ${cityName} is ${temperature} degrees from weather station ${station}.`,
+          llmResult: {
+            success: true,
+            message: `The temperature in ${cityName} is ${temperature} degrees from weather station ${station}.`,
+          },
           output: {
             cityName,
             temperature,

--- a/packages/core/esbuild.config.mjs
+++ b/packages/core/esbuild.config.mjs
@@ -2,11 +2,12 @@ import { createBaseConfig, buildFormat } from '../../esbuild.config.mjs';
 import { dtsPlugin } from 'esbuild-plugin-d.ts';
 
 const baseConfig = createBaseConfig({
-  minify: false,
+  minify: true,
   sourcemap: true,
   entryPoints: ['src/index.ts'],
   external: [
     'react',
+    '@ai-sdk/anthropic',
     '@ai-sdk/deepseek',
     '@ai-sdk/google',
     '@ai-sdk/openai',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@openassistant/core",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "Core library using Vercel AI SDK for OpenAssistant",
+  "type": "module",
   "main": "src/index.ts",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
@@ -27,23 +28,39 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@ai-sdk/anthropic": "^1.1.14",
-    "@ai-sdk/deepseek": "^0.1.8",
-    "@ai-sdk/google": "^1.1.8",
     "@ai-sdk/openai": "^1.1.5",
     "@ai-sdk/react": "^1.1.7",
     "@ai-sdk/ui-utils": "^1.1.8",
-    "@ai-sdk/xai": "^1.1.8",
     "@langchain/core": "^0.3.38",
     "ai": "^4.1.12",
-    "ollama-ai-provider": "^1.2.0",
-    "openai": "^4.82.0",
     "openai-zod-functions": "^0.1.2",
     "zod": "^3.24.1",
     "zod-to-json-schema": "^3.24.1"
   },
   "peerDependencies": {
+    "@ai-sdk/anthropic": "^1.1.14",
+    "@ai-sdk/deepseek": "^0.1.8",
+    "@ai-sdk/google": "^1.1.8",
+    "@ai-sdk/xai": "^1.1.8",
+    "ollama-ai-provider": "^1.2.0",
     "react": ">=18.2"
+  },
+  "peerDependenciesMeta": {
+    "@ai-sdk/anthropic": {
+      "optional": true
+    },
+    "@ai-sdk/deepseek": {
+      "optional": true
+    },
+    "@ai-sdk/google": {
+      "optional": true
+    },
+    "@ai-sdk/xai": {
+      "optional": true
+    },
+    "ollama-ai-provider": {
+      "optional": true
+    }
   },
   "files": [
     "dist",

--- a/packages/core/src/llm/anthropic.ts
+++ b/packages/core/src/llm/anthropic.ts
@@ -1,13 +1,18 @@
 import {
-  createAnthropic,
-  AnthropicProvider,
-  AnthropicProviderSettings,
-} from '@ai-sdk/anthropic';
-import {
   VercelAiClient,
   VercelAiClientConfigureProps,
 } from './vercelai-client';
 import { testConnection } from '../utils/connection-test';
+import { LanguageModelV1 } from 'ai';
+
+type AnthropicProvider = (model: string) => LanguageModelV1;
+interface Module {
+  createAnthropic: (options: {
+    apiKey: string;
+    baseURL: string;
+    headers: Record<string, string>;
+  }) => AnthropicProvider;
+}
 
 /**
  * Anthropic Assistant LLM for Client only
@@ -33,45 +38,64 @@ export class AnthropicAssistant extends VercelAiClient {
     super.configure(config);
   }
 
+  private static async loadModule(): Promise<Module> {
+    try {
+      // @ts-expect-error dynamic import
+      return await import('@ai-sdk/anthropic');
+    } catch (error) {
+      throw new Error(`Failed to load @ai-sdk/anthropic: ${error}`);
+    }
+  }
+
   public static async testConnection(
     apiKey: string,
     model: string
   ): Promise<boolean> {
-    const anthropic = createAnthropic({
+    const module = await this.loadModule();
+    const anthropic = module.createAnthropic({
       apiKey,
+      baseURL: AnthropicAssistant.baseURL,
       headers: AnthropicAssistant.headers,
     });
     return await testConnection(anthropic(model));
   }
 
-  private constructor() {
+  private constructor(module: Module) {
     super();
+    this.initializeProvider(module);
+  }
 
-    if (AnthropicAssistant.apiKey) {
-      // only apiKey is provided, so we can create the Anthropic LLM instance in the client
-      const options: AnthropicProviderSettings = {
-        apiKey: AnthropicAssistant.apiKey,
-        baseURL: AnthropicAssistant.baseURL,
-        headers: { 'anthropic-dangerous-direct-browser-access': 'true' },
-      };
-
-      // Initialize Anthropic instance
-      this.providerInstance = createAnthropic(options);
-
-      // create a language model from the provider instance
-      this.llm = this.providerInstance(AnthropicAssistant.model);
+  private initializeProvider(module: Module) {
+    if (!AnthropicAssistant.apiKey) {
+      return;
     }
+
+    const options = {
+      apiKey: AnthropicAssistant.apiKey,
+      baseURL: AnthropicAssistant.baseURL,
+      headers: AnthropicAssistant.headers,
+    };
+
+    this.providerInstance = module.createAnthropic(options);
+
+    if (!this.providerInstance) {
+      throw new Error('Failed to initialize Anthropic');
+    }
+
+    this.llm = this.providerInstance(AnthropicAssistant.model);
   }
 
   public static async getInstance(): Promise<AnthropicAssistant> {
-    if (AnthropicAssistant.instance === null) {
-      AnthropicAssistant.instance = new AnthropicAssistant();
+    if (!AnthropicAssistant.instance) {
+      const module = await this.loadModule();
+      AnthropicAssistant.instance = new AnthropicAssistant(module);
     }
-    if (AnthropicAssistant.instance.llm === null) {
-      // reset the instance so getInstance doesn't return the same instance
+
+    if (!AnthropicAssistant.instance.llm) {
       AnthropicAssistant.instance.restart();
       throw new Error('AnthropicAssistant is not initialized');
     }
+
     return AnthropicAssistant.instance;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,18 +22,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/anthropic@npm:^1.1.14":
-  version: 1.1.14
-  resolution: "@ai-sdk/anthropic@npm:1.1.14"
-  dependencies:
-    "@ai-sdk/provider": "npm:1.0.9"
-    "@ai-sdk/provider-utils": "npm:2.1.10"
-  peerDependencies:
-    zod: ^3.0.0
-  checksum: 43dee55be38737f328790c8042353a50c348ef0e97169de3c7e91293adaa05cd8d308dd4ac722bd7dd79c1e9f6b90733bda56fe6bf111713a9c97b441a175cd9
-  languageName: node
-  linkType: hard
-
 "@ai-sdk/deepseek@npm:^0.1.8":
   version: 0.1.12
   resolution: "@ai-sdk/deepseek@npm:0.1.12"
@@ -7334,22 +7322,32 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openassistant/core@workspace:packages/core"
   dependencies:
-    "@ai-sdk/anthropic": "npm:^1.1.14"
-    "@ai-sdk/deepseek": "npm:^0.1.8"
-    "@ai-sdk/google": "npm:^1.1.8"
     "@ai-sdk/openai": "npm:^1.1.5"
     "@ai-sdk/react": "npm:^1.1.7"
     "@ai-sdk/ui-utils": "npm:^1.1.8"
-    "@ai-sdk/xai": "npm:^1.1.8"
     "@langchain/core": "npm:^0.3.38"
     ai: "npm:^4.1.12"
-    ollama-ai-provider: "npm:^1.2.0"
-    openai: "npm:^4.82.0"
     openai-zod-functions: "npm:^0.1.2"
     zod: "npm:^3.24.1"
     zod-to-json-schema: "npm:^3.24.1"
   peerDependencies:
+    "@ai-sdk/anthropic": ^1.1.14
+    "@ai-sdk/deepseek": ^0.1.8
+    "@ai-sdk/google": ^1.1.8
+    "@ai-sdk/xai": ^1.1.8
+    ollama-ai-provider: ^1.2.0
     react: ">=18.2"
+  peerDependenciesMeta:
+    "@ai-sdk/anthropic":
+      optional: true
+    "@ai-sdk/deepseek":
+      optional: true
+    "@ai-sdk/google":
+      optional: true
+    "@ai-sdk/xai":
+      optional: true
+    ollama-ai-provider:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

provide a way to avoid installing deepseek/anthropic dependencies when installing sqlrooms/ai.

- use peerDependenciesMeta in package.json to achieve it. 
- with dynamic import the dependencies, users will need to manually install the dependencies. 

Something like:
```
"peerDependenciesMeta": {
    "@ai-sdk/anthropic": {
      "optional": true
    },
    "@ai-sdk/deepseek": {
      "optional": true
    }
  },
```